### PR TITLE
snapshot must be flagged current before update_versionless is called in Snapshot.set_current()

### DIFF
--- a/src/pyasm/biz/snapshot.py
+++ b/src/pyasm/biz/snapshot.py
@@ -1056,13 +1056,13 @@ class Snapshot(SObject):
             last_current.set_value("is_current", False)
             last_current.commit()
 
-        # if there is a versionless, point it to this snapshot
-        if update_versionless:
-            my.update_versionless("current")
-
         my.set_value("is_current", True)
         if commit:
             my.commit()
+
+        # if there is a versionless, point it to this snapshot
+        if update_versionless:
+            my.update_versionless("current")
 
 
 


### PR DESCRIPTION
If any non-current snapshot is set as current using `tactic_client_lib.TacticServerStub.set_current_snapshot()`, the current versionless snapshot is not updated. This because none of the snapshots are flagged as `*is_current*` when `Snapshot.update_versionless` is called. 

This pull request suggests that `my` snapshot should be flagged as current before calling `update_versionless`.
